### PR TITLE
feat: Enable simd vectors for x86

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,6 +72,7 @@ AM_CONDITIONAL(TESTSUBDIR, test -d $srcdir/testsuite)
 
 TARGETDIR="unknown"
 HAVE_LONG_DOUBLE_VARIANT=0
+HAVE_EXT_VECTOR=0
 
 . ${srcdir}/configure.host
 
@@ -106,6 +107,7 @@ if test -z "$HAVE_LONG_DOUBLE"; then
 fi
 AC_SUBST(HAVE_LONG_DOUBLE)
 AC_SUBST(HAVE_LONG_DOUBLE_VARIANT)
+AC_SUBST(HAVE_EXT_VECTOR)
 
 AC_C_BIGENDIAN
 
@@ -202,6 +204,12 @@ case "$target" in
                  [Cannot use malloc on this target, so, we revert to
                    alternative means])
      ;;
+esac
+
+
+case "$target" in
+     aarch64-apple-darwin* | x86_64-apple-darwin*)
+       HAVE_EXT_VECTOR=1
 esac
 
 AM_CONDITIONAL(FFI_EXEC_TRAMPOLINE_TABLE, test x$FFI_EXEC_TRAMPOLINE_TABLE = x1)
@@ -348,7 +356,7 @@ AC_ARG_ENABLE(purify-safety,
 AC_ARG_ENABLE(multi-os-directory,
 [  --disable-multi-os-directory
                           disable use of gcc --print-multi-os-directory to change the library installation directory])
-                          
+
 # These variables are only ever used when we cross-build to X86_WIN32.
 # And we only support this with GCC, so...
 if test "x$GCC" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,6 @@ AM_CONDITIONAL(TESTSUBDIR, test -d $srcdir/testsuite)
 
 TARGETDIR="unknown"
 HAVE_LONG_DOUBLE_VARIANT=0
-HAVE_EXT_VECTOR=0
 
 . ${srcdir}/configure.host
 
@@ -107,7 +106,6 @@ if test -z "$HAVE_LONG_DOUBLE"; then
 fi
 AC_SUBST(HAVE_LONG_DOUBLE)
 AC_SUBST(HAVE_LONG_DOUBLE_VARIANT)
-AC_SUBST(HAVE_EXT_VECTOR)
 
 AC_C_BIGENDIAN
 
@@ -206,11 +204,6 @@ case "$target" in
      ;;
 esac
 
-
-case "$target" in
-     aarch64-apple-darwin*)
-       HAVE_EXT_VECTOR=1
-esac
 AM_CONDITIONAL(FFI_EXEC_TRAMPOLINE_TABLE, test x$FFI_EXEC_TRAMPOLINE_TABLE = x1)
 AC_SUBST(FFI_EXEC_TRAMPOLINE_TABLE)
 

--- a/configure.host
+++ b/configure.host
@@ -7,7 +7,6 @@
 # Most of the time we can define all the variables all at once...
 case "${host}" in
   aarch64*-*-*)
-  	HAVE_EXT_VECTOR=1
 	TARGET=AARCH64; TARGETDIR=aarch64
 	SOURCES="ffi.c sysv.S"
 	;;

--- a/configure.host
+++ b/configure.host
@@ -7,6 +7,7 @@
 # Most of the time we can define all the variables all at once...
 case "${host}" in
   aarch64*-*-*)
+  	HAVE_EXT_VECTOR=1
 	TARGET=AARCH64; TARGETDIR=aarch64
 	SOURCES="ffi.c sysv.S"
 	;;
@@ -93,6 +94,7 @@ case "${host}" in
 	;;
 
   i?86-*-darwin* | x86_64-*-darwin* | i?86-*-ios | x86_64-*-ios)
+    HAVE_EXT_VECTOR=1
 	TARGETDIR=x86
 	if test $ac_cv_sizeof_size_t = 4; then
 	  TARGET=X86_DARWIN
@@ -102,6 +104,7 @@ case "${host}" in
 	;;
 
   i?86-*-* | x86_64-*-* | amd64-*)
+    HAVE_EXT_VECTOR=1
 	TARGETDIR=x86
 	if test $ac_cv_sizeof_size_t = 4; then
 	  case "$host" in

--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -477,10 +477,18 @@ ffi_status ffi_get_struct_offsets (ffi_abi abi, ffi_type *struct_type,
 #define FFI_TYPE_STRUCT     13
 #define FFI_TYPE_POINTER    14
 #define FFI_TYPE_COMPLEX    15
+#if @HAVE_EXT_VECTOR@
 #define FFI_TYPE_EXT_VECTOR 16
+#else
+#define FFI_TYPE_EXT_VECTOR FFI_TYPE_STRUCT
+#endif
 
 /* This should always refer to the last type code (for sanity checks).  */
-#define FFI_TYPE_LAST  FFI_TYPE_EXT_VECTOR   
+#if @HAVE_EXT_VECTOR@
+#define FFI_TYPE_LAST  FFI_TYPE_EXT_VECTOR
+#else
+#define FFI_TYPE_LAST  FFI_TYPE_COMPLEX
+#endif    
 
 #ifdef __cplusplus
 }

--- a/include/ffi.h.in
+++ b/include/ffi.h.in
@@ -477,18 +477,10 @@ ffi_status ffi_get_struct_offsets (ffi_abi abi, ffi_type *struct_type,
 #define FFI_TYPE_STRUCT     13
 #define FFI_TYPE_POINTER    14
 #define FFI_TYPE_COMPLEX    15
-#if @HAVE_EXT_VECTOR@
 #define FFI_TYPE_EXT_VECTOR 16
-#else
-#define FFI_TYPE_EXT_VECTOR FFI_TYPE_STRUCT
-#endif
 
 /* This should always refer to the last type code (for sanity checks).  */
-#if @HAVE_EXT_VECTOR@
-#define FFI_TYPE_LAST  FFI_TYPE_EXT_VECTOR
-#else
-#define FFI_TYPE_LAST  FFI_TYPE_COMPLEX
-#endif    
+#define FFI_TYPE_LAST  FFI_TYPE_EXT_VECTOR   
 
 #ifdef __cplusplus
 }

--- a/src/aarch64/ffi.c
+++ b/src/aarch64/ffi.c
@@ -246,7 +246,8 @@ is_vfp_type (const ffi_type *ty)
     default:
       return 0;
     }
-  if ((ele_count > 4 && !simd_size) || (simd_size && ele_count > 16))
+  /* SIMD values bigger than 16 bytes are returned in memory as they cannot be packed in a single register */
+  if ((ele_count > 4 && !simd_size) || (simd_size && ele_count > 16) || simd_size > 16)
     return 0;
 
   /* Finally, make sure that all scalar elements are the same type.  */

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -86,10 +86,7 @@ enum x86_64_reg_class
   {
     X86_64_NO_CLASS,
     X86_64_INTEGER_CLASS,
-    X86_64_INTEGERSI_CLASS,
     X86_64_SSE_CLASS,
-    X86_64_SSESF_CLASS,
-    X86_64_SSEDF_CLASS,
     X86_64_SSEUP_CLASS,
     X86_64_X87_CLASS,
     X86_64_X87UP_CLASS,
@@ -101,6 +98,142 @@ enum x86_64_reg_class
 
 #define SSE_CLASS_P(X)	((X) >= X86_64_SSE_CLASS && X <= X86_64_SSEUP_CLASS)
 
+/* A subroutine of is_vfp_type.Given a structure type,
+ return the type code of the first non - structure element.Recurse
+ for structure elements.
+ Return - 1
+ if the structure is in fact empty, i.e.no nested elements.*/
+
+static int
+is_hfa0(const ffi_type* ty) {
+  ffi_type** elements = ty->elements;
+  int i, ret = -1;
+
+  if (elements != NULL)
+    for (i = 0; elements[i]; ++i) {
+      ret = elements[i]->type;
+      if (ret == FFI_TYPE_STRUCT || ret == FFI_TYPE_EXT_VECTOR || ret == FFI_TYPE_COMPLEX) {
+        ret = is_hfa0(elements[i]);
+        if (ret < 0)
+          continue;
+      }
+      break;
+    }
+
+  return ret;
+}
+
+/* A subroutine of is_vfp_type.  Given a structure type, return true if all
+ of the non-structure elements are the same as CANDIDATE.  */
+
+static int
+is_hfa1(const ffi_type* ty, int candidate) {
+  ffi_type** elements = ty->elements;
+  int i;
+
+  if (elements != NULL)
+    for (i = 0; elements[i]; ++i) {
+      int t = elements[i]->type;
+      if (t == FFI_TYPE_STRUCT || t == FFI_TYPE_COMPLEX || t == FFI_TYPE_EXT_VECTOR) {
+        if (!is_hfa1(elements[i], candidate))
+          return 0;
+      } else if (t != candidate)
+        return 0;
+    }
+
+  return 1;
+}
+
+static size_t is_simd(const ffi_type* ty) // return 0 if no SIMD elements
+{
+  if (ty->type == FFI_TYPE_EXT_VECTOR || ty->type == FFI_TYPE_COMPLEX) {
+    return ty  ->size;
+  }
+  ffi_type ** elements = ty ->elements;
+  int i;
+
+  if (elements != NULL) {
+    for (i = 0; elements[i]; ++i) {
+      int element_type = elements[i] ->type;
+      if (element_type == FFI_TYPE_STRUCT || element_type == FFI_TYPE_COMPLEX || element_type == FFI_TYPE_EXT_VECTOR) {
+        return is_simd(elements[i]);
+      }
+    }
+  }
+
+  return 0;
+
+}
+
+int num_registers(ffi_cif* cif) {
+  int candidate;
+  size_t size, ele_count, simd_size;
+
+  ffi_type** elements = cif->rtype->elements;
+  size = cif->rtype ->size;
+  candidate = cif->rtype ->elements[0] ->type;
+  simd_size = is_simd(cif ->rtype);
+  if (candidate == FFI_TYPE_STRUCT || candidate == FFI_TYPE_COMPLEX || candidate == FFI_TYPE_EXT_VECTOR) {
+    for (int i = 0;; ++i) {
+      candidate = is_hfa0(elements[i]);
+      if (candidate >= 0)
+        break;
+    }
+  }
+
+  switch (candidate) {
+    case FFI_TYPE_FLOAT:
+      ele_count = size / sizeof(float);
+      if (size != ele_count * sizeof(float))
+        return 0;
+      break;
+    case FFI_TYPE_DOUBLE:
+      ele_count = size / sizeof(double);
+      if (size != ele_count * sizeof(double))
+        return 0;
+      break;
+    case FFI_TYPE_LONGDOUBLE:
+      ele_count = size / sizeof(long double);
+      if (size != ele_count * sizeof(long double))
+        return 0;
+      break;
+    default:
+        return 0;
+  }
+  if ((ele_count > 4 && !simd_size) || (simd_size && ele_count > 16))
+    return 0;
+
+  /* Finally, make sure that all scalar elements are the same type.  */
+  for (int i = 0; elements[i]; ++i) {
+    int t = elements[i]->type;
+    if (t == FFI_TYPE_STRUCT || t == FFI_TYPE_COMPLEX || t == FFI_TYPE_EXT_VECTOR) {
+      if (!is_hfa1(elements[i], candidate))
+        return 0;
+    } else if (t != candidate)
+        return 0;
+  }
+
+  if (simd_size) {
+    if (candidate == FFI_TYPE_DOUBLE && ele_count == 3) {
+      return 3;
+    }
+    size_t regSize = simd_size > 16 ? 16 : simd_size;
+    return (int) size / regSize + (size % regSize ? 1 : 0);
+  }
+  return 0;
+}
+
+static enum x86_64_reg_class normalize_sse_class(enum x86_64_reg_class class, int byte_offset, _Bool is_vector) {
+  if (SSE_CLASS_P(class)) {
+    if (is_vector) {
+      return byte_offset >= 8 ? X86_64_SSEUP_CLASS : X86_64_SSE_CLASS;
+    }
+    return X86_64_SSE_CLASS;
+  }
+
+  return class;
+}
+
 /* x86-64 register passing implementation.  See x86-64 ABI for details.  Goal
    of this code is to classify each 8bytes of incoming argument by the register
    class and assign registers accordingly.  */
@@ -109,30 +242,26 @@ enum x86_64_reg_class
    See the x86-64 PS ABI for details.  */
 
 static enum x86_64_reg_class
-merge_classes (enum x86_64_reg_class class1, enum x86_64_reg_class class2)
+merge_classes (enum x86_64_reg_class class1, enum x86_64_reg_class class2, int byte_offset, _Bool is_vector)
 {
   /* Rule #1: If both classes are equal, this is the resulting class.  */
   if (class1 == class2)
-    return class1;
+    return normalize_sse_class(class1, byte_offset, is_vector);
 
   /* Rule #2: If one of the classes is NO_CLASS, the resulting class is
      the other class.  */
   if (class1 == X86_64_NO_CLASS)
-    return class2;
+    return normalize_sse_class(class2, byte_offset, is_vector);
   if (class2 == X86_64_NO_CLASS)
-    return class1;
+    return normalize_sse_class(class1, byte_offset, is_vector);
 
   /* Rule #3: If one of the classes is MEMORY, the result is MEMORY.  */
   if (class1 == X86_64_MEMORY_CLASS || class2 == X86_64_MEMORY_CLASS)
     return X86_64_MEMORY_CLASS;
 
   /* Rule #4: If one of the classes is INTEGER, the result is INTEGER.  */
-  if ((class1 == X86_64_INTEGERSI_CLASS && class2 == X86_64_SSESF_CLASS)
-      || (class2 == X86_64_INTEGERSI_CLASS && class1 == X86_64_SSESF_CLASS))
-    return X86_64_INTEGERSI_CLASS;
-  if (class1 == X86_64_INTEGER_CLASS || class1 == X86_64_INTEGERSI_CLASS
-      || class2 == X86_64_INTEGER_CLASS || class2 == X86_64_INTEGERSI_CLASS)
-    return X86_64_INTEGER_CLASS;
+  if (class1 == X86_64_INTEGER_CLASS || class2 == X86_64_INTEGER_CLASS)
+      return X86_64_INTEGER_CLASS;
 
   /* Rule #5: If one of the classes is X87, X87UP, or COMPLEX_X87 class,
      MEMORY is used.  */
@@ -158,7 +287,7 @@ merge_classes (enum x86_64_reg_class class1, enum x86_64_reg_class class2)
 */
 static size_t
 classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
-		   size_t byte_offset)
+		   size_t byte_offset, _Bool is_vector)
 {
   switch (type->type)
     {
@@ -177,7 +306,7 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
 
 	if (size <= 4)
 	  {
-	    classes[0] = X86_64_INTEGERSI_CLASS;
+	    classes[0] = X86_64_INTEGER_CLASS;
 	    return 1;
 	  }
 	else if (size <= 8)
@@ -188,7 +317,7 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
 	else if (size <= 12)
 	  {
 	    classes[0] = X86_64_INTEGER_CLASS;
-	    classes[1] = X86_64_INTEGERSI_CLASS;
+	    classes[1] = X86_64_INTEGER_CLASS;
 	    return 2;
 	  }
 	else if (size <= 16)
@@ -200,13 +329,10 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
 	  FFI_ASSERT (0);
       }
     case FFI_TYPE_FLOAT:
-      if (!(byte_offset % 8))
-	classes[0] = X86_64_SSESF_CLASS;
-      else
-	classes[0] = X86_64_SSE_CLASS;
+      classes[0] = X86_64_SSE_CLASS;
       return 1;
     case FFI_TYPE_DOUBLE:
-      classes[0] = X86_64_SSEDF_CLASS;
+      classes[0] = X86_64_SSE_CLASS;
       return 1;
 #if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
     case FFI_TYPE_LONGDOUBLE:
@@ -215,6 +341,14 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
       return 2;
 #endif
     case FFI_TYPE_STRUCT:
+      // If the size of an object is larger than two eightbytes, or in C++, is a nonPOD
+      // structure or union type, or contains unaligned fields, it has class
+      // MEMORY.
+      if (type->size > 16) {
+          return 0;
+      }
+      // fallthrough case
+    case FFI_TYPE_EXT_VECTOR:
       {
 	const size_t UNITS_PER_WORD = 8;
 	size_t words = (type->size + UNITS_PER_WORD - 1) / UNITS_PER_WORD;
@@ -245,14 +379,14 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
 
 	    byte_offset = FFI_ALIGN (byte_offset, (*ptr)->alignment);
 
-	    num = classify_argument (*ptr, subclasses, byte_offset % 8);
+	    num = classify_argument (*ptr, subclasses, byte_offset % 8, is_vector);
 	    if (num == 0)
 	      return 0;
 	    for (i = 0; i < num; i++)
 	      {
 		size_t pos = byte_offset / 8;
 		classes[i + pos] =
-		  merge_classes (subclasses[i], classes[i + pos]);
+		  merge_classes (subclasses[i], classes[i + pos], (int)byte_offset, is_vector);
 	      }
 
 	    byte_offset += (*ptr)->size;
@@ -321,14 +455,9 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
 
 	  case FFI_TYPE_FLOAT:
 	    classes[0] = X86_64_SSE_CLASS;
-	    if (byte_offset % 8)
-	      {
-		classes[1] = X86_64_SSESF_CLASS;
-		return 2;
-	      }
-	    return 1;
+      return 1;
 	  case FFI_TYPE_DOUBLE:
-	    classes[0] = classes[1] = X86_64_SSEDF_CLASS;
+	    classes[0] = classes[1] = X86_64_SSE_CLASS;
 	    return 2;
 #if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
 	  case FFI_TYPE_LONGDOUBLE:
@@ -347,13 +476,13 @@ classify_argument (ffi_type *type, enum x86_64_reg_class classes[],
 
 static size_t
 examine_argument (ffi_type *type, enum x86_64_reg_class classes[MAX_CLASSES],
-		  _Bool in_return, int *pngpr, int *pnsse)
+		  _Bool in_return, int *pngpr, int *pnsse, _Bool is_vector)
 {
   size_t n;
   unsigned int i;
   int ngpr, nsse;
 
-  n = classify_argument (type, classes, 0);
+  n = classify_argument (type, classes, 0, is_vector);
   if (n == 0)
     return 0;
 
@@ -362,16 +491,13 @@ examine_argument (ffi_type *type, enum x86_64_reg_class classes[MAX_CLASSES],
     switch (classes[i])
       {
       case X86_64_INTEGER_CLASS:
-      case X86_64_INTEGERSI_CLASS:
 	ngpr++;
 	break;
       case X86_64_SSE_CLASS:
-      case X86_64_SSESF_CLASS:
-      case X86_64_SSEDF_CLASS:
+      case X86_64_SSEUP_CLASS:
 	nsse++;
 	break;
       case X86_64_NO_CLASS:
-      case X86_64_SSEUP_CLASS:
 	break;
       case X86_64_X87_CLASS:
       case X86_64_X87UP_CLASS:
@@ -455,7 +581,8 @@ ffi_prep_cif_machdep (ffi_cif *cif)
       flags = UNIX64_RET_X87;
       break;
     case FFI_TYPE_STRUCT:
-      n = examine_argument (cif->rtype, classes, 1, &ngpr, &nsse);
+    case FFI_TYPE_EXT_VECTOR:
+      n = examine_argument (cif->rtype, classes, 1, &ngpr, &nsse, rtype->type == FFI_TYPE_EXT_VECTOR);
       if (n == 0)
 	{
 	  /* The return value is passed in memory.  A pointer to that
@@ -475,14 +602,24 @@ ffi_prep_cif_machdep (ffi_cif *cif)
 	  else
 	    {
 	      _Bool sse1 = n == 2 && SSE_CLASS_P (classes[1]);
-	      if (sse0 && sse1)
-		flags = UNIX64_RET_ST_XMM0_XMM1;
-	      else if (sse0)
-		flags = UNIX64_RET_ST_XMM0_RAX;
-	      else if (sse1)
-		flags = UNIX64_RET_ST_RAX_XMM0;
-	      else
-		flags = UNIX64_RET_ST_RAX_RDX;
+	      if (sse0) {
+          int num_regs = num_registers(cif);
+          if (num_regs == 1) {
+            flags = UNIX64_RET_ST_XMM0;
+          } else if (num_regs == 2) {
+            flags = rtype_size > 16 ? UNIX64_RET_ST_XMM0_XMM1_128 : UNIX64_RET_ST_XMM0_XMM1_64;
+          } else if (num_regs == 3) {
+            flags = UNIX64_RET_X86_ST0;
+          } else if (sse1) {
+            flags = UNIX64_RET_ST_XMM0_XMM1_64;
+          } else {
+            flags = UNIX64_RET_ST_XMM0_RAX;
+          }
+        } else if (sse1) {
+          flags = UNIX64_RET_ST_RAX_XMM0;
+        } else {
+          flags = UNIX64_RET_ST_RAX_RDX;
+        }
 	      flags |= rtype_size << UNIX64_SIZE_SHIFT;
 	    }
 	}
@@ -505,7 +642,7 @@ ffi_prep_cif_machdep (ffi_cif *cif)
 	  flags = UNIX64_RET_XMM64;
 	  break;
 	case FFI_TYPE_DOUBLE:
-	  flags = UNIX64_RET_ST_XMM0_XMM1 | (16 << UNIX64_SIZE_SHIFT);
+	  flags = UNIX64_RET_ST_XMM0_XMM1_64 | (16 << UNIX64_SIZE_SHIFT);
 	  break;
 #if FFI_TYPE_LONGDOUBLE != FFI_TYPE_DOUBLE
 	case FFI_TYPE_LONGDOUBLE:
@@ -525,7 +662,7 @@ ffi_prep_cif_machdep (ffi_cif *cif)
      not, add it's size to the stack byte count.  */
   for (bytes = 0, i = 0, avn = cif->nargs; i < avn; i++)
     {
-      if (examine_argument (cif->arg_types[i], classes, 0, &ngpr, &nsse) == 0
+      if (examine_argument (cif->arg_types[i], classes, 0, &ngpr, &nsse, rtype->type == FFI_TYPE_EXT_VECTOR) == 0
 	  || gprcount + ngpr > MAX_GPR_REGS
 	  || ssecount + nsse > MAX_SSE_REGS)
 	{
@@ -597,7 +734,7 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
     {
       size_t n, size = arg_types[i]->size;
 
-      n = examine_argument (arg_types[i], classes, 0, &ngpr, &nsse);
+      n = examine_argument (arg_types[i], classes, 0, &ngpr, &nsse, cif->rtype->type == FFI_TYPE_EXT_VECTOR);
       if (n == 0
 	  || gprcount + ngpr > MAX_GPR_REGS
 	  || ssecount + nsse > MAX_SSE_REGS)
@@ -624,10 +761,8 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 	      switch (classes[j])
 		{
 		case X86_64_NO_CLASS:
-		case X86_64_SSEUP_CLASS:
 		  break;
 		case X86_64_INTEGER_CLASS:
-		case X86_64_INTEGERSI_CLASS:
 		  /* Sign-extend integer arguments passed in general
 		     purpose registers, to cope with the fact that
 		     LLVM incorrectly assumes that this will be done
@@ -650,11 +785,12 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 		  gprcount++;
 		  break;
 		case X86_64_SSE_CLASS:
-		case X86_64_SSEDF_CLASS:
-		  memcpy (&reg_args->sse[ssecount++].i64, a, sizeof(UINT64));
-		  break;
-		case X86_64_SSESF_CLASS:
-		  memcpy (&reg_args->sse[ssecount++].i32, a, sizeof(UINT32));
+		case X86_64_SSEUP_CLASS:
+		  if (size > 4) {
+        memcpy (&reg_args->sse[ssecount++].i64, a, sizeof(UINT64));
+      } else {
+        memcpy (&reg_args->sse[ssecount++].i32, a, sizeof(UINT32));
+      }
 		  break;
 		default:
 		  abort();
@@ -788,7 +924,7 @@ ffi_closure_unix64_inner(ffi_cif *cif,
       enum x86_64_reg_class classes[MAX_CLASSES];
       size_t n;
 
-      n = examine_argument (arg_types[i], classes, 0, &ngpr, &nsse);
+      n = examine_argument (arg_types[i], classes, 0, &ngpr, &nsse, cif->rtype == FFI_TYPE_EXT_VECTOR);
       if (n == 0
 	  || gprcount + ngpr > MAX_GPR_REGS
 	  || ssecount + nsse > MAX_SSE_REGS)

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -789,14 +789,14 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 		    break;
 		case X86_64_SSE_CLASS:
           if (size > 4) {
-            memcpy (&reg_args->sse[ssecount++].i128, a, sizeof(UINT64));
+            memcpy (&reg_args->sse[ssecount++].i64, a, sizeof(UINT64));
           } else {
             memcpy (&reg_args->sse[ssecount++].i32, a, sizeof(UINT32));
           }
           break;
 		case X86_64_SSEUP_CLASS:
           if (j%2) {
-            memcpy (&reg_args->sse[ssecount-1].i128 + 1, a, sizeof(UINT64));
+            memcpy (&reg_args->sse[ssecount-1].i64 + 1, a, sizeof(UINT64));
           } else {
             memcpy (&reg_args->sse[ssecount++].i128, a, sizeof(UINT64));
           }

--- a/src/x86/ffi64.c
+++ b/src/x86/ffi64.c
@@ -273,9 +273,8 @@ merge_classes (enum x86_64_reg_class class1, enum x86_64_reg_class class2, int b
       || class2 == X86_64_X87UP_CLASS
       || class2 == X86_64_COMPLEX_X87_CLASS)
     return X86_64_MEMORY_CLASS;
-
-  /* Rule #6: Otherwise class SSE is used.  */
-  return X86_64_SSE_CLASS;
+  
+  return byte_offset >= 8 ? X86_64_SSEUP_CLASS : X86_64_SSE_CLASS;
 }
 
 /* Classify the argument of type TYPE and mode MODE.
@@ -789,12 +788,18 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *rvalue,
 		    gprcount++;
 		    break;
 		case X86_64_SSE_CLASS:
+          if (size > 4) {
+            memcpy (&reg_args->sse[ssecount++].i128, a, sizeof(UINT64));
+          } else {
+            memcpy (&reg_args->sse[ssecount++].i32, a, sizeof(UINT32));
+          }
+          break;
 		case X86_64_SSEUP_CLASS:
-		  if (size > 4) {
-        memcpy (&reg_args->sse[ssecount++].i64, a, sizeof(UINT64));
-      } else {
-        memcpy (&reg_args->sse[ssecount++].i32, a, sizeof(UINT32));
-      }
+          if (j%2) {
+            memcpy (&reg_args->sse[ssecount-1].i128 + 1, a, sizeof(UINT64));
+          } else {
+            memcpy (&reg_args->sse[ssecount++].i128, a, sizeof(UINT64));
+          }
 		  break;
 		default:
 		  abort();

--- a/src/x86/internal64.h
+++ b/src/x86/internal64.h
@@ -1,22 +1,30 @@
-#define UNIX64_RET_VOID		0
-#define UNIX64_RET_UINT8	1
-#define UNIX64_RET_UINT16	2
-#define UNIX64_RET_UINT32	3
-#define UNIX64_RET_SINT8	4
-#define UNIX64_RET_SINT16	5
-#define UNIX64_RET_SINT32	6
-#define UNIX64_RET_INT64	7
-#define UNIX64_RET_XMM32	8
-#define UNIX64_RET_XMM64	9
-#define UNIX64_RET_X87		10
-#define UNIX64_RET_X87_2	11
-#define UNIX64_RET_ST_XMM0_RAX	12
-#define UNIX64_RET_ST_RAX_XMM0	13
-#define UNIX64_RET_ST_XMM0_XMM1	14
-#define UNIX64_RET_ST_RAX_RDX	15
+#ifdef __x86_64__
 
-#define UNIX64_RET_LAST		15
+#define UNIX64_RET_VOID               0
+#define UNIX64_RET_UINT8              1
+#define UNIX64_RET_UINT16             2
+#define UNIX64_RET_UINT32             3
+#define UNIX64_RET_SINT8              4
+#define UNIX64_RET_SINT16             5
+#define UNIX64_RET_SINT32             6
+#define UNIX64_RET_INT64              7
+#define UNIX64_RET_XMM32              8
+#define UNIX64_RET_XMM64              9
+#define UNIX64_RET_X87                10
+#define UNIX64_RET_X87_2              11
+#define UNIX64_RET_ST_XMM0_RAX        12
+#define UNIX64_RET_ST_RAX_XMM0        13
+#define UNIX64_RET_ST_XMM0_XMM1_64    14
+#define UNIX64_RET_ST_XMM0_XMM1_128   15
+#define UNIX64_RET_ST_XMM0            16
+#define UNIX64_RET_ST_RAX_RDX         17
+#define UNIX64_RET_X86_ST0            18
 
-#define UNIX64_FLAG_RET_IN_MEM	(1 << 10)
-#define UNIX64_FLAG_XMM_ARGS	(1 << 11)
-#define UNIX64_SIZE_SHIFT	12
+#define UNIX64_RET_LAST        18
+
+#define UNIX64_FLAG_RET_IN_MEM    (1 << 10)
+#define UNIX64_FLAG_XMM_ARGS    (1 << 11)
+#define UNIX64_SIZE_SHIFT    12
+
+
+#endif

--- a/src/x86/unix64.S
+++ b/src/x86/unix64.S
@@ -358,8 +358,7 @@ E(L(load_table), UNIX64_RET_ST_XMM0_XMM1_128)
 	movq	16(%rsi), %xmm1
 	jmp	L(l4)
 E(L(load_table), UNIX64_RET_ST_XMM0)
-	movdqu  (%rsi), %xmm0
-	ret
+	jmp	L(l4)
 E(L(load_table), UNIX64_RET_ST_RAX_RDX)
 	movq	8(%rsi), %rdx
     jmp    L(l2)

--- a/src/x86/unix64.S
+++ b/src/x86/unix64.S
@@ -3,7 +3,7 @@
 	    - Copyright (c) 2008  Red Hat, Inc
 	    - Copyright (c) 2002  Bo Thorsen <bo@suse.de>
 
-   x86-64 Foreign Function Interface 
+   x86-64 Foreign Function Interface
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -27,7 +27,7 @@
    ----------------------------------------------------------------------- */
 
 #ifdef __x86_64__
-#define LIBFFI_ASM	
+#define LIBFFI_ASM
 #include <fficonfig.h>
 #include <ffi.h>
 #include "internal64.h"
@@ -172,11 +172,21 @@ E(L(store_table), UNIX64_RET_ST_XMM0_RAX)
 E(L(store_table), UNIX64_RET_ST_RAX_XMM0)
 	movq	%xmm0, 8(%rsi)
 	jmp	L(s2)
-E(L(store_table), UNIX64_RET_ST_XMM0_XMM1)
+E(L(store_table), UNIX64_RET_ST_XMM0_XMM1_64)
 	movq	%xmm1, 8(%rsi)
 	jmp	L(s3)
+E(L(store_table), UNIX64_RET_ST_XMM0_XMM1_128)
+	movdqu    %xmm1, 16(%rdi)
+	jmp    L(s4)
+E(L(store_table), UNIX64_RET_ST_XMM0)
+	movdqu    %xmm0, (%rsi)
+	jmp    L(s3)
 E(L(store_table), UNIX64_RET_ST_RAX_RDX)
 	movq	%rdx, 8(%rsi)
+	jmp    L(s2)
+E(L(store_table), UNIX64_RET_X86_ST0)
+	fstpl   16(%rdi)
+	jmp     L(s5)
 L(s2):
 	movq	%rax, (%rsi)
 	shrl	$UNIX64_SIZE_SHIFT, %ecx
@@ -187,6 +197,13 @@ L(s3):
 	movq	%xmm0, (%rsi)
 	shrl	$UNIX64_SIZE_SHIFT, %ecx
 	rep movsb
+	ret
+L(s4):
+	movdqu    %xmm0, (%rdi)
+	ret
+L(s5):
+	movq    %xmm1, 8(%rdi)
+	movq    %xmm0, (%rdi)
 	ret
 
 L(sa):	call	PLT(C(abort))
@@ -334,17 +351,30 @@ E(L(load_table), UNIX64_RET_ST_XMM0_RAX)
 E(L(load_table), UNIX64_RET_ST_RAX_XMM0)
 	movq	8(%rsi), %xmm0
 	jmp	L(l2)
-E(L(load_table), UNIX64_RET_ST_XMM0_XMM1)
+E(L(load_table), UNIX64_RET_ST_XMM0_XMM1_64)
 	movq	8(%rsi), %xmm1
 	jmp	L(l3)
+E(L(load_table), UNIX64_RET_ST_XMM0_XMM1_128)
+	movq	16(%rsi), %xmm1
+	jmp	L(l4)
+E(L(load_table), UNIX64_RET_ST_XMM0)
+	movdqu  (%rsi), %xmm0
+	ret
 E(L(load_table), UNIX64_RET_ST_RAX_RDX)
 	movq	8(%rsi), %rdx
+    jmp    L(l2)
+E(L(load_table), UNIX64_RET_X86_ST0)
+	movdqa  16(%rsi), %xmm1
+	jmp     L(l4)
 L(l2):
 	movq	(%rsi), %rax
 	ret
 	.balign	8
 L(l3):
 	movq	(%rsi), %xmm0
+	ret
+L(l4):
+	movdqa  (%rsi), %xmm0
 	ret
 
 L(la):	call	PLT(C(abort))


### PR DESCRIPTION
The current implementation for x86(unix64) doesn't handle SSE types properly. It turned out that simd matrices were working just because they are passed in memory (i.e. there is not a specific logic for simd types). 

In order to distinguish between simd vectors and structs **FFI_TYPE_EXT_VECTOR** is introduced in x86 as well as flags for handling the following cases(which were apparently missing):

1. **UNIX64_RET_ST_XMM0** - *simd_float4* (128 bits) type is being returned in an entire xmm register
2. **UNIX64_RET_ST_XMM0_XMM1_64** (ex. UNIX64_RET_ST_XMM0_XMM1) - handles values returned in first 64 bits of XMM0 and XMM1 but not working when we need entire registers.
3. **_UNIX64_RET_ST_XMM0_XMM1_128** - when entire XMM0 and XMM1 content is needed (e.g. *simd_double4*)
4. **UNIX64_RET_X86_ST0** - when returned value is a *simd_double3* the third element is in *ST0*.

The whole unix64 logic has been refactored in order to fulfill [x86 ABI](https://software.intel.com/sites/default/files/article/402129/mpx-linux64-abi.pdf) requirements. *SSESF, SSEDF and INTEGERSI* register classes has been removed as they are not mentioned in the ABI. Instead float and integer values are handled as described there.

In addition, same logic as in *arm64* is implemented in order to derive register count for *simd* values.